### PR TITLE
Clone fix chat page refreshing before saving chat

### DIFF
--- a/components/chat.tsx
+++ b/components/chat.tsx
@@ -1,5 +1,7 @@
 'use client'
 
+import type { AI } from '@/lib/chat/actions'
+
 import { cn } from '@/lib/utils'
 import { ChatList } from '@/components/chat-list'
 import { ChatPanel } from '@/components/chat-panel'
@@ -24,7 +26,7 @@ export function Chat({ id, className, session, missingKeys }: ChatProps) {
   const path = usePathname()
   const [input, setInput] = useState('')
   const [messages] = useUIState()
-  const [aiState] = useAIState()
+  const [aiState] = useAIState<typeof AI>()
 
   const [_, setNewChatId] = useLocalStorage('newChatId', id)
 
@@ -39,6 +41,8 @@ export function Chat({ id, className, session, missingKeys }: ChatProps) {
   useEffect(() => {
     const messagesLength = aiState.messages?.length
     if (messagesLength === 2) {
+      router.refresh()
+    } else if (messagesLength === 3 && aiState.messages[2].role === 'tool') {
       router.refresh()
     }
   }, [aiState.messages, router])

--- a/components/stocks/stock-purchase.tsx
+++ b/components/stocks/stock-purchase.tsx
@@ -63,40 +63,40 @@ export function Purchase({
 
   useEffect(() => {
     const checkPurchaseStatus = () => {
-      if (purchaseStatus === 'requires_action') {
-        // check for purchase completion
-        // Find the tool message with the matching toolCallId
-        const toolMessage = aiState.messages.find(
-          message => 
-            message.role === 'tool' && 
-            message.content.some(part => part.toolCallId === toolCallId)
-        );
+      if (purchaseStatus !== 'requires_action') {
+        return;
+      }
+      // check for purchase completion
+      // Find the tool message with the matching toolCallId
+      const toolMessage = aiState.messages.find(
+        message =>
+          message.role === 'tool' &&
+          message.content.some(part => part.toolCallId === toolCallId)
+      );
 
-        if (toolMessage) {
-          const toolMessageIndex = aiState.messages.indexOf(toolMessage);
-          // Check if the next message is a system message containing "purchased"
-          const nextMessage = aiState.messages[toolMessageIndex + 1];
-          if (
-            nextMessage?.role === 'system' &&
-            nextMessage.content.includes('purchased')
-          ) {
-            setPurchaseStatus('completed');
-          } else {
-            // Check for expiration
-            const requestedAt = toolMessage.createdAt;
-            if (!requestedAt || unixTsNow() - requestedAt > 30) {
-              setPurchaseStatus('expired');
-            }
+      if (toolMessage) {
+        const toolMessageIndex = aiState.messages.indexOf(toolMessage);
+        // Check if the next message is a system message containing "purchased"
+        const nextMessage = aiState.messages[toolMessageIndex + 1];
+        if (
+          nextMessage?.role === 'system' &&
+          nextMessage.content.includes('purchased')
+        ) {
+          setPurchaseStatus('completed');
+        } else {
+          // Check for expiration
+          const requestedAt = toolMessage.createdAt;
+          if (!requestedAt || unixTsNow() - requestedAt > 30) {
+            setPurchaseStatus('expired');
           }
         }
       }
     };
-
     checkPurchaseStatus();
 
     let intervalId: NodeJS.Timeout | null = null;
     if (purchaseStatus === 'requires_action') {
-      intervalId = setInterval(checkPurchaseStatus, 1000);
+      intervalId = setInterval(checkPurchaseStatus, 5000);
     }
 
     return () => {

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -2,6 +2,7 @@ import { CoreMessage } from 'ai'
 
 export type Message = CoreMessage & {
   id: string
+  createdAt?: number;
 }
 
 export interface Chat extends Record<string, any> {
@@ -39,3 +40,9 @@ export interface User extends Record<string, any> {
   password: string
   salt: string
 }
+
+export type MutableAIState<AIState> = {
+  get: () => AIState;
+  update: (newState: AIState | ((current: AIState) => AIState)) => void;
+  done: ((newState: AIState) => void) | (() => void);
+};

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -51,8 +51,10 @@ export const formatNumber = (value: number) =>
 export const runAsyncFnWithoutBlocking = (
   fn: (...args: any) => Promise<any>
 ) => {
-  fn()
-}
+  fn().catch(error => {
+    console.error('An error occurred in the async function:', error);
+  });
+};
 
 export const sleep = (ms: number) =>
   new Promise(resolve => setTimeout(resolve, ms))
@@ -87,3 +89,5 @@ export const getMessageFromCode = (resultCode: string) => {
       return 'Logged in!'
   }
 }
+
+export const unixTsNow = () => Math.floor(Date.now() / 1000);


### PR DESCRIPTION
## **CodeAnt-AI Description**
Prevent chat page refresh before the chat is saved and stabilize stock purchase flow

### What Changed
- The chat UI no longer refreshes before the chat has been saved to the database, preventing the page from reloading prematurely and losing in-progress state
- Stock purchase cards now poll for completion every 5 seconds instead of every second and show three concrete states: requires_action, completed, or expired (checkout expires after ~30s)
- Purchase messages carry a timestamp and a tool call identifier so the UI reliably detects completed purchases; purchase UI updates immediately when completion or expiration is detected
- Background async errors are caught and logged to avoid unhandled exceptions from small helper tasks

### Impact
`✅ No premature chat refreshes before save`
`✅ Fewer purchase polling cycles (lower client CPU and network usage)`
`✅ Clearer purchase completion and expiration feedback`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Stock purchases now automatically monitor status updates every 5 seconds.
  * Messages now include creation timestamps.

* **Improvements**
  * Enhanced chat state persistence and synchronization for better reliability.
  * Improved error logging in background operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->